### PR TITLE
Causal StrAF refactor

### DIFF
--- a/data/causal_sem.py
+++ b/data/causal_sem.py
@@ -229,9 +229,16 @@ class SparseSEM(LinAddSEM):
 
         Args:
             dimension: Size of the graph
-            noise_mean_param: Parameters to generate noise mean
-            noise_std_param: Parameters to generate noise std
-            adj_gen_param: Parameters to generate adjacency weight matrix
+            noise_mean_param:
+                Range of uniform distribution used to generate noise
+                distribution means.
+            noise_std_param:
+                Range of uniform distribution used to generate noise
+                distribution standard deviations.
+            adj_gen_param:
+                Range of uniform distribution used to generate DAG edge
+                coefficients. Note that values less than 1.5 in absolute
+                value are rounded to zero.
         """
         self.n_var = dimension
 

--- a/data/causal_sem.py
+++ b/data/causal_sem.py
@@ -212,7 +212,7 @@ class RandomSEM(LinAddSEM):
         adj_mat = uniform(*adj_gen_param, size=(dimension, dimension))
         self.adj_mat = np.tril(adj_mat)
 
-        super().init__(self.noise_means, self.noise_stds, self.adj_mat)
+        super().__init__(self.noise_means, self.noise_stds, self.adj_mat)
 
 
 class SparseSEM(LinAddSEM):

--- a/data/causal_sem.py
+++ b/data/causal_sem.py
@@ -1,28 +1,40 @@
 import numpy as np
+from numpy.random import normal, uniform
+
 import torch
-from numpy.random import normal, uniform, laplace
 from torch.utils.data import Dataset
+
+from typing import Callable
 
 
 class LinAddSEM:
-    """
-    Defines a linear additive SEM and sampling operations.
-    """
-    def __init__(self, noise_mean, noise_stds, adj_mat, noise_dist=normal):
-        """Initialize SEM.
+    """Defines a linear additive SEM and sampling operations."""
 
-        All input variables should be np.array.
+    def __init__(
+        self,
+        noise_mean: np.ndarray,
+        noise_stds: np.ndarray,
+        adj_mat: np.ndarray,
+        noise_dist: Callable = normal
+    ):
+        """Initialize Linear Additive SEM.
 
         Assumes autoregressive causal ordering, meaning adjacency matrix must
         be lower triangular.
+
+        Args:
+            noise_mean: Means of the noise distributions. Has shape (D,).
+            noise_stds: Standard dev. of noise distributions. Has shape (D,).
+            adj_mat: Adjacency matrix of SEM. Has shape (D, D).
+            noise_dist: Noise generating distribution
         """
         # Check that SEM specification is valid
-        assert(len(noise_mean) == len(noise_stds))
+        assert len(noise_mean) == len(noise_stds)
 
-        assert(len(adj_mat.shape) == 2)
-        assert(adj_mat.shape[0] == adj_mat.shape[1])
-        assert(len(noise_mean) == adj_mat.shape[0])
-        assert(np.allclose(adj_mat, np.tril(adj_mat)))
+        assert len(adj_mat.shape) == 2
+        assert adj_mat.shape[0] == adj_mat.shape[1]
+        assert len(noise_mean) == adj_mat.shape[0]
+        assert np.allclose(adj_mat, np.tril(adj_mat))
 
         self.n_var = len(noise_mean)
 
@@ -31,8 +43,12 @@ class LinAddSEM:
         self.noise_dist = noise_dist
         self.adj_mat = adj_mat
 
-    def generate_sample(self):
-        """Generates a sample from specified SEM."""
+    def generate_sample(self) -> np.ndarray:
+        """Generate a sample from specified SEM.
+
+        Returns:
+            Single sample generated from SEM
+        """
         e = self.noise_dist(self.noise_mean, self.noise_stds)
 
         out_mat = np.zeros_like(e)
@@ -42,10 +58,25 @@ class LinAddSEM:
 
         return out_mat
 
-    def generate_samples(self, n_samp):
+    def generate_samples(self, n_samp: int) -> np.ndarray:
+        """Generate multiple samples from SEM.
+
+        Returns:
+            Samples from SEM in shape (n_samp, n_dim)
+        """
         return np.array([self.generate_sample() for _ in range(n_samp)])
 
-    def generate_intervention(self, int_val):
+    def generate_intervention(self, int_val: list[float | None]) -> np.ndarray:
+        """Generate ground truth intervention on variables.
+
+        Args:
+            int_val:
+                Intervenational values. Has shape (D,), but each position can
+                be None to indicate no intervention in specific variable.
+
+        Returns:
+            Sample generated under intervention
+        """
         e = self.noise_dist(self.noise_mean, self.noise_stds)
 
         out_mat = np.zeros_like(e)
@@ -58,7 +89,26 @@ class LinAddSEM:
 
         return out_mat
 
-    def generate_int_dist(self, int_val, n_samp, return_mean=True):
+    def generate_int_dist(
+        self,
+        int_val: list[float | None],
+        n_samp: int,
+        return_mean: bool = True
+    ) -> np.ndarray:
+        """Estimate ground truth interventional distribution.
+
+        Generates samples under intervention, and optionally returns mean.
+
+        Args:
+            int_val:
+                Intervenational values. Has shape (D,), but each position can
+                be None to indicate no intervention in specific variable.
+            n_samp: Number of samples used to estimate distribution
+            return_mean: Whether mean of samples should be taken
+
+        Returns:
+            Interventional samples, or mean of interventional samples
+        """
         samples = []
         for _ in range(n_samp):
             samples.append(self.generate_intervention(int_val))
@@ -68,8 +118,15 @@ class LinAddSEM:
         else:
             return np.array(samples)
 
-    def generate_ctf_obs(self):
-        """Generates an obs from specified SEM, return both obs and noise."""
+    def generate_ctf_obs(self) -> tuple[np.ndarray, np.ndarray]:
+        """Generate an sample from specified SEM, return both obs and noise.
+
+        Return of noise that generated sample can be used to generate ground
+        truth values for counterfactual queries.
+
+        Returns:
+            Sample from SEM, and noise that generated sample
+        """
         e = self.noise_dist(self.noise_mean, self.noise_stds)
 
         out_mat = np.zeros_like(e)
@@ -79,8 +136,22 @@ class LinAddSEM:
 
         return out_mat, e
 
-    def generate_counterfactual(self, e, ctf_val):
+    def generate_counterfactual(
+        self,
+        e: np.ndarray,
+        ctf_val: list[float | None]
+    ) -> np.ndarray:
+        """Generate ground truth counterfactual outcome.
 
+        Args:
+            e: Noise used to generate original sample of interest
+            ctf_val:
+                Counterfactual values. Has shape (D,), but each position can
+                be None to indicate no counterfactual in specific variable.
+
+        Returns:
+            Counterfactual outcome of sample
+        """
         out_mat = np.zeros_like(e)
 
         for i, row in enumerate(self.adj_mat):
@@ -91,29 +162,46 @@ class LinAddSEM:
 
         return out_mat
 
-    def get_carefl_ds(self, n_samp):
-        X = self.generate_samples(n_samp)
-
-        # Generate binary adjacency matrix
-        cfl_adj_mat = (self.adj_mat != 0).astype(int)
-        np.fill_diagonal(cfl_adj_mat, 0)
-
-        return X, None, cfl_adj_mat
-
-
-class RandomSEM:
-    """Initializes a random LinAddSEM."""
-
-    def __init__(self, dimension, noise_mean_param=(-2, 2),
-                 noise_std_param=(1, 10), adj_gen_param=(-2, 2)):
-        """Initialize SEM.
+    def get_carefl_ds(
+        self,
+        n_samp: int
+    ) -> tuple[np.ndarray, None, np.ndarray]:
+        """Generate dataset using SEM.
 
         Args:
-            dimension (int): Size of the graph.
-            noise_mean_param (float, float): Parameters to generate noise mean.
-            noise_std_param (float, float): Parameters to generate noise std.
-            adj_gen_param (float, float): Parameters to generate adjacency
-                                          weight matrix.
+            n_samp: Number of samples in dataset
+
+        Returns:
+            Samples, unused, and adjacency matrix
+        """
+        X = self.generate_samples(n_samp)
+
+        return X, None, self.get_adj_mat()
+
+    def get_adj_mat(self) -> np.ndarray:
+        """Return adjacency matrix associated with SEM."""
+        bin_adj_mat = (self.adj_mat != 0).astype(int)
+        np.fill_diagonal(bin_adj_mat, 0)
+        return bin_adj_mat
+
+
+class RandomSEM(LinAddSEM):
+    """Initializes a LinAddSEM with randomly sampled coefficients."""
+
+    def __init__(
+        self,
+        dimension: int,
+        noise_mean_param: tuple[float, float] = (-2, 2),
+        noise_std_param: tuple[float, float] = (1, 10),
+        adj_gen_param: tuple[float, float] = (-2, 2)
+    ):
+        """Initialize SEM with random coefficients.
+
+        Args:
+            dimension: Size of the graph
+            noise_mean_param: Parameters to generate noise mean
+            noise_std_param: Parameters to generate noise std
+            adj_gen_param: Parameters to generate adjacency weight matrix
         """
         self.n_var = dimension
 
@@ -124,33 +212,26 @@ class RandomSEM:
         adj_mat = uniform(*adj_gen_param, size=(dimension, dimension))
         self.adj_mat = np.tril(adj_mat)
 
-        self.sem = LinAddSEM(self.noise_means, self.noise_stds, self.adj_mat)
-
-    def generate_samples(self, n_samples):
-        return self.sem.generate_samples(n_samples)
-
-    def generate_int_dist(self, int_val, n_samples):
-        return self.sem.generate_int_dist(int_val, n_samples)
-
-    def get_adj_mat(self):
-        bin_adj_mat = (self.adj_mat != 0).astype(int)
-        np.fill_diagonal(bin_adj_mat, 0)
-        return bin_adj_mat
+        super().init__(self.noise_means, self.noise_stds, self.adj_mat)
 
 
-class SparseSEM:
+class SparseSEM(LinAddSEM):
     """Initializes a LinAddSEM with many independencies."""
 
-    def __init__(self, dimension, noise_mean_param=(-1, 1),
-                 noise_std_param=(1, 1), adj_gen_param=(-2, 2)):
-        """Initialize SEM.
+    def __init__(
+        self,
+        dimension: int,
+        noise_mean_param: tuple[int, int] = (-1, 1),
+        noise_std_param: tuple[int, int] = (1, 1),
+        adj_gen_param: tuple[int, int] = (-2, 2)
+    ):
+        """Initialize a SEM with a highly sparse adjacency.
 
         Args:
-            dimension (int): Size of the graph.
-            noise_mean_param (float, float): Parameters to generate noise mean.
-            noise_std_param (float, float): Parameters to generate noise std.
-            adj_gen_param (float, float): Parameters to generate adjacency
-                                          weight matrix.
+            dimension: Size of the graph
+            noise_mean_param: Parameters to generate noise mean
+            noise_std_param: Parameters to generate noise std
+            adj_gen_param: Parameters to generate adjacency weight matrix
         """
         self.n_var = dimension
 
@@ -167,43 +248,33 @@ class SparseSEM:
 
         self.adj_mat = adj_mat
 
-        self.sem = LinAddSEM(self.noise_means, self.noise_stds, self.adj_mat)
+        super().__init__(self.noise_means, self.noise_stds, self.adj_mat)
 
-    def generate_samples(self, n_samples):
-        return self.sem.generate_samples(n_samples)
-
-    def generate_int_dist(self, int_val, n_samples, return_mean=True):
-        return self.sem.generate_int_dist(int_val, n_samples, return_mean)
-
-    def generate_ctf_obs(self):
-        return self.sem.generate_ctf_obs()
-
-    def generate_counterfactual(self, e, ctf_val):
-        return self.sem.generate_counterfactual(e, ctf_val)
-
-    def get_adj_mat(self):
-        bin_adj_mat = (self.adj_mat != 0).astype(int)
-        np.fill_diagonal(bin_adj_mat, 0)
-        return bin_adj_mat
-    
 
 class CustomSyntheticDatasetDensity(Dataset):
-    def __init__(self, X, device='cpu'):
+    """PyTorch Dataset wrapper for Causal SEMs."""
+
+    def __init__(self, X: np.ndarray, device: str = 'cpu'):
+        """Initialize torch dataset used to wrap causal SEMs."""
         self.device = device
         self.x = torch.from_numpy(X).to(device)
         self.len = self.x.shape[0]
         self.data_dim = self.x.shape[1]
 
-    def get_dims(self):
+    def get_dims(self) -> int:
+        """Get feature dimensionality of data."""
         return self.data_dim
 
-    def __len__(self):
+    def __len__(self) -> int:
+        """Return length of dataset."""
         return self.len
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> torch.Tensor:
+        """Return single datum from dataset."""
         return self.x[index]
 
-    def get_metadata(self):
+    def get_metadata(self) -> dict:
+        """Return dataset statistics."""
         return {
             'n': self.len,
             'data_dim': self.data_dim,

--- a/data/data_utils.py
+++ b/data/data_utils.py
@@ -12,7 +12,7 @@ def split_dataset(
     data: np.ndarray,
     split_ratio: tuple[float, float, float]
 ) -> DSTuple:
-    """Splits data into train, validation, and test splits.
+    """Split data into train, validation, and test splits.
 
     Args:
         data: Dataset to split. Assumes first dimension is sample dimension.
@@ -29,7 +29,7 @@ def split_dataset(
 
 
 def standardize_data(data: np.ndarray):
-    """Standardizes data.
+    """Standardize data.
 
     Args:
         data: Data of dimension (n_samples, n_features).

--- a/data/make_adj_mtx.py
+++ b/data/make_adj_mtx.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 def generate_adj_mat_uniform(data_dim: int, threshold: float) -> np.ndarray:
-    """Generates adjacency matrix with uniform sparsity.
+    """Generate adjacency matrix with uniform sparsity.
 
     Args:
         data_dim: Dimension of data.

--- a/experiments/synthetic_causality/config/baseline.yaml
+++ b/experiments/synthetic_causality/config/baseline.yaml
@@ -9,12 +9,7 @@ carefl:
 flow:
   nl: 5
   nh: 10
-  batch_norm: false
   prior_dist: 'laplace'
-  # for CL
-  # scale_base: true
-  # shift_base: true
-  # scale: true
 
 
 training:
@@ -23,6 +18,7 @@ training:
   split: .8
   seed: 0
   batch_size: 32
+  early_stop_patience: 25
 
 
 optim:

--- a/experiments/synthetic_causality/config/masked.yaml
+++ b/experiments/synthetic_causality/config/masked.yaml
@@ -11,12 +11,7 @@ straf:
 flow:
   nl: 5
   nh: 10
-  batch_norm: false
   prior_dist: 'laplace'
-  # for CL
-  # scale_base: true
-  # shift_base: true
-  # scale: true
 
 
 training:
@@ -25,6 +20,7 @@ training:
   split: .8
   seed: 0
   batch_size: 32
+  early_stop_patience: 25
 
 
 optim:

--- a/experiments/synthetic_causality/evaluation.py
+++ b/experiments/synthetic_causality/evaluation.py
@@ -1,14 +1,28 @@
 import numpy as np
 from tqdm import tqdm
 
+from data.causal_sem import LinAddSEM
+from strnn.models.causal_arflow import CausalAutoregressiveFlowWithPrior
 
-def evaluate_intervention(sem, model, train_data, n_eval_points, n_dist_samp):
+
+def evaluate_intervention(
+    sem: LinAddSEM,
+    model: CausalAutoregressiveFlowWithPrior,
+    train_data: np.ndarray,
+    n_eval_points: int,
+    n_dist_samp: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Evaluate interventional distribution for all variables.
 
     Args:
-        ...
-        n_eval_points (int): Number of interventional values to compute.
-        n_dist_samp (int): Number of flow samples used to compute distribution.
+        sem: Data generating SEM
+        model: Autoregressive flow fit to SEM
+        train_data: Data used to train flow model
+        n_eval_points: Number of interventional values to compute
+        n_dist_samp: Number of flow samples used to compute distribution
+
+    Return:
+        Truth interventional mean, predicted mean, and interventional values
     """
     emp_means = np.mean(train_data, axis=0)
 
@@ -31,16 +45,18 @@ def evaluate_intervention(sem, model, train_data, n_eval_points, n_dist_samp):
         val_mat[int_ind] = eval_vals
 
         for i, int_val in enumerate(eval_vals):
-            int_input = [None] * sem.n_var
+            int_input: list[float | None] = [None] * sem.n_var
             int_input[int_ind] = int_val
 
             true_dist = sem.generate_int_dist(int_input, n_dist_samp)
 
             while True:
                 try:
-                    p_dist = model.predict_intervention_modified(int_val,
-                                                                 n_dist_samp,
-                                                                 iidx=int_ind)
+                    p_dist = model.predict_intervention(
+                        int_val,
+                        n_dist_samp,
+                        iidx=int_ind
+                    )
                     p_dist = p_dist[0]
                 except ValueError:
                     continue
@@ -55,7 +71,31 @@ def evaluate_intervention(sem, model, train_data, n_eval_points, n_dist_samp):
     return true_mat, pred_mat, val_mat
 
 
-def evaluate_counterfactual(sem, model, train_data, n_eval_points, n_cf_samp):
+def evaluate_counterfactual(
+    sem: LinAddSEM,
+    model: CausalAutoregressiveFlowWithPrior,
+    train_data: np.ndarray,
+    n_eval_points: int,
+    n_cf_samp: int
+) -> np.ndarray:
+    """Evaluate counterfactual estimation accuracy for all variables.
+
+    For each variable in the SEM, computes the counterfactual estimation
+    accuracy across a range of values.
+
+    Args:
+        sem: Data generating SEM
+        model: Autoregressive flow fit to SEM
+        train_data: Data used to train flow model
+        n_eval_points: Number of values used to evaluate each variable
+        n_cf_samp: Number of samples used per variable evaluation
+
+    Returns:
+        Matrix of errors in estimating counterfactuals. Output has shape
+        (D x D x n_eval_points), which can be interpreted as the effect of
+        the counterfactual value (last output dimension) for each variable
+        (first output dimension) on subsequent variables (second dimension)
+    """
     emp_means = np.mean(train_data, axis=0)
 
     # Stores counterfactual values
@@ -69,29 +109,43 @@ def evaluate_counterfactual(sem, model, train_data, n_eval_points, n_cf_samp):
         eval_vals = np.arange(int(var_mean) - pad, int(var_mean) + pad, step=1)
 
         for i, cf_val in enumerate(eval_vals):
-            cf_input = [None] * sem.n_var
+            cf_input: list[float | None] = [None] * sem.n_var
             cf_input[cf_ind] = cf_val
 
             errors = []
             for _ in range(n_cf_samp):
                 obs, e = sem.generate_ctf_obs()
-                
+
                 ctf_true = sem.generate_counterfactual(e, cf_input)
-                
-                p_dist = model.predict_counterfactual(obs.reshape(1,-1),
-                                                      cf_val,
-                                                      iidx=cf_ind)[0]
+
+                p_dist = model.predict_counterfactual(
+                    obs.reshape(1, -1),
+                    cf_val,
+                    iidx=cf_ind
+                )[0]
+
                 # Only evaluate error past cf index
                 error = sum((ctf_true[cf_ind:] - p_dist[cf_ind:]) ** 2)
                 errors.append(error)
-            
+
             err_mat[cf_ind+1:, cf_ind, i] = np.mean(errors)
 
     return err_mat
 
 
-def get_nrmse(true_dist, pred_dist):
-    """Get the normalized root MSE in estimation per variable."""
+def get_nrmse(
+    true_dist: np.ndarray,
+    pred_dist: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute normalized root MSE in estimation per variable.
+
+    Args:
+        true_dist: Samples from first distribution
+        pred_dist: Samples from second distribution
+
+    Returns:
+        Overall normalized root MSE and per-variable normalized root MSE
+    """
     sq_error = ((true_dist - pred_dist) ** 2)
 
     # Average error across evaluations
@@ -107,7 +161,19 @@ def get_nrmse(true_dist, pred_dist):
     return avg_err, var_err
 
 
-def get_mse(true_dist, pred_dist):
+def get_mse(
+    true_dist: np.ndarray,
+    pred_dist: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute MSE between samples from two distributions.
+
+    Args:
+        true_dist: Samples from first distribution
+        pred_dist: Samples from second distribution
+
+    Returns:
+        Overall MSE and per-variable MSE
+    """
     sq_error = ((true_dist - pred_dist) ** 2)
 
     # Average error across evaluations

--- a/experiments/synthetic_causality/evaluation.py
+++ b/experiments/synthetic_causality/evaluation.py
@@ -65,8 +65,8 @@ def evaluate_intervention(
                 break
 
             # Exclude interventional variable, and preceding variables
-            true_mat[int_ind+1:, int_ind, i] = true_dist[int_ind+1:]
-            pred_mat[int_ind+1:, int_ind, i] = p_dist[int_ind+1:]
+            true_mat[int_ind + 1:, int_ind, i] = true_dist[int_ind + 1:]
+            pred_mat[int_ind + 1:, int_ind, i] = p_dist[int_ind + 1:]
 
     return true_mat, pred_mat, val_mat
 
@@ -128,7 +128,7 @@ def evaluate_counterfactual(
                 error = sum((ctf_true[cf_ind:] - p_dist[cf_ind:]) ** 2)
                 errors.append(error)
 
-            err_mat[cf_ind+1:, cf_ind, i] = np.mean(errors)
+            err_mat[cf_ind + 1:, cf_ind, i] = np.mean(errors)
 
     return err_mat
 

--- a/experiments/synthetic_causality/run_experiment.py
+++ b/experiments/synthetic_causality/run_experiment.py
@@ -13,8 +13,10 @@ from utils import dict2namespace
 from strnn.models.config_constants import *
 from strnn.models.causal_arflow import CausalARFlowTrainer
 
-BL_CONFIG_PATH = "./config/baseline.yaml"
-FM_CONFIG_PATH = "./config/masked.yaml"
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+CAREFL_CONFIG_PATH = "./config/baseline.yaml"
+STRAF_CONFIG_PATH = "./config/masked.yaml"
 
 parser = argparse.ArgumentParser("Runs flows on causal synthetic dataset.")
 parser.add_argument("--n_graph_vars", type=int, required=True)
@@ -65,86 +67,94 @@ def main():
 
     sem = SparseSEM(args.n_graph_vars)
 
-    overall_bl_error = []
-    overall_fm_error = []
-
     if args.eval == "nrmse":
         eval_func = get_nrmse
     else:
         eval_func = get_mse
 
     # Load non-masked carefl config
-    bl_config_file = open(BL_CONFIG_PATH, "r")
-    bl_config_raw = yaml.load(bl_config_file, Loader=yaml.FullLoader)
-    bl_config = dict2namespace(bl_config_raw)
-    bl_config.device = torch.device('cpu')
-    bl_config.flow.nl = args.flow_steps
-    bl_config.flow.nh = args.hidden_width
-    bl_config.training.epochs = args.train_epochs
-    bl_config.training.verbose = False
+    carefl_config_file = open(CAREFL_CONFIG_PATH, "r")
+    carefl_config_raw = yaml.load(carefl_config_file, Loader=yaml.FullLoader)
+    carefl_config = dict2namespace(carefl_config_raw)
+    carefl_config.device = device
+    carefl_config.flow.nl = args.flow_steps
+    carefl_config.flow.nh = args.hidden_width
+    carefl_config.training.epochs = args.train_epochs
 
-    bl_arch_config = bl_config_raw["carefl"]
-    bl_arch_config = get_model_config(args, bl_arch_config)
-    bl_config.arch_config = bl_arch_config
+    carefl_arch_config = carefl_config_raw["carefl"]
+    carefl_arch_config = get_model_config(args, carefl_arch_config)
+    carefl_config.arch_config = carefl_arch_config
 
     # Load masked straf config
-    fm_config_file = open(FM_CONFIG_PATH, "r")
-    fm_config_raw = yaml.load(fm_config_file, Loader=yaml.FullLoader)
-    fm_config = dict2namespace(fm_config_raw)
-    fm_config.device = torch.device('cpu')
-    fm_config.flow.nl = args.flow_steps
-    fm_config.flow.nh = args.hidden_width
-    fm_config.training.epochs = args.train_epochs
-    fm_config.training.verbose = False
+    straf_config_file = open(STRAF_CONFIG_PATH, "r")
+    straf_config_raw = yaml.load(straf_config_file, Loader=yaml.FullLoader)
+    straf_config = dict2namespace(straf_config_raw)
+    straf_config.device = device
+    straf_config.flow.nl = args.flow_steps
+    straf_config.flow.nh = args.hidden_width
+    straf_config.training.epochs = args.train_epochs
 
-    fm_arch_config = fm_config_raw["straf"]
-    fm_arch_config = get_model_config(args, fm_arch_config)
-    fm_config.arch_config = fm_arch_config
+    straf_arch_config = straf_config_raw["straf"]
+    straf_arch_config = get_model_config(args, straf_arch_config)
+    straf_config.arch_config = straf_arch_config
+
+    overall_carefl_error = []
+    overall_straf_error = []
 
     for _ in range(args.n_trials):
-        # Vary sample generation
         dataset = sem.generate_samples(args.data_samples)
         bin_adj_mat = sem.get_adj_mat()
 
-        bl_config.arch_config[ADJ] = None
-        fm_config.arch_config[ADJ] = bin_adj_mat
+        carefl_config.arch_config[ADJ] = None
+        straf_config.arch_config[ADJ] = bin_adj_mat
 
-        carefl = CausalARFlowTrainer(bl_config)
-        straf = CausalARFlowTrainer(fm_config)
+        carefl = CausalARFlowTrainer(carefl_config)
+        straf = CausalARFlowTrainer(straf_config)
 
         # Train models
         carefl.fit_to_sem(dataset)
         straf.fit_to_sem(dataset)
 
         # Evaluate
-        bl_true, bl_pred, _ = evaluate_intervention(sem, carefl.flow, dataset,
-                                                    args.n_eval_points,
-                                                    args.n_dist_samples)
-        fm_true, fm_pred, _ = evaluate_intervention(sem, straf.flow, dataset,
-                                                    args.n_eval_points,
-                                                    args.n_dist_samples)
+        carefl_true, carefl_pred, _ = evaluate_intervention(
+            sem,
+            carefl.flow,
+            dataset,
+            args.n_eval_points,
+            args.n_dist_samples
+        )
 
-        bl_err, _ = eval_func(bl_true, bl_pred)
-        fm_err, _ = eval_func(fm_true, fm_pred)
+        straf_true, straf_pred, _ = evaluate_intervention(
+            sem,
+            straf.flow,
+            dataset,
+            args.n_eval_points,
+            args.n_dist_samples
+        )
 
-        bl_err = np.nanmean(bl_err)
-        fm_err = np.nanmean(fm_err)
+        carefl_err, _ = eval_func(carefl_true, carefl_pred)
+        straf_err, _ = eval_func(straf_true, straf_pred)
 
-        overall_bl_error.append(bl_err)
-        overall_fm_error.append(fm_err)
+        carefl_err = np.nanmean(carefl_err)
+        straf_err = np.nanmean(straf_err)
 
-    print(np.nanmean(overall_bl_error), np.nanstd(overall_bl_error))
-    print(np.nanmean(overall_fm_error), np.nanstd(overall_fm_error))
+        overall_carefl_error.append(carefl_err)
+        overall_straf_error.append(straf_err)
+
+    print(np.nanmean(overall_carefl_error), np.nanstd(overall_carefl_error))
+    print(np.nanmean(overall_straf_error), np.nanstd(overall_straf_error))
 
     exp_output = {
         "args": args,
-        "bl_out": overall_bl_error,
-        "fm_out": overall_fm_error,
+        "carefl_out": overall_carefl_error,
+        "straf_out": overall_straf_error,
         "sem": sem
     }
 
+    output_dir_name = "./output/"
     output_dir = Path("./output/")
     output_dir.mkdir(parents=False, exist_ok=True)
+
     out_fn = "linadd{}_{}hid_{}obs_{}runs_{}"
 
     out_fn = out_fn.format(
@@ -155,7 +165,7 @@ def main():
         args.eval
     )
 
-    torch.save(exp_output, output_dir + out_fn + ".pt")
+    torch.save(exp_output, output_dir_name + out_fn + ".pt")
 
 
 if __name__ == "__main__":

--- a/experiments/synthetic_causality/run_experiment.py
+++ b/experiments/synthetic_causality/run_experiment.py
@@ -1,4 +1,5 @@
 import argparse
+from pathlib import Path
 
 import numpy as np
 import yaml
@@ -58,6 +59,7 @@ def get_model_config(args: argparse.Namespace, config: dict) -> dict:
 
 
 def main():
+    """Generate SEM dataset and evaluate both CAREFL and Causal StrAF."""
     np.random.seed(args.graph_seed)
     torch.manual_seed(2541)
 
@@ -141,7 +143,8 @@ def main():
         "sem": sem
     }
 
-    output_dir = "./output/"
+    output_dir = Path("./output/")
+    output_dir.mkdir(parents=False, exist_ok=True)
     out_fn = "linadd{}_{}hid_{}obs_{}runs_{}"
 
     out_fn = out_fn.format(

--- a/experiments/synthetic_causality/run_experiment.py
+++ b/experiments/synthetic_causality/run_experiment.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 
 import numpy as np
 import yaml
@@ -11,7 +10,7 @@ from data.causal_sem import SparseSEM
 
 from utils import dict2namespace
 from strnn.models.config_constants import *
-from strnn.models.causal_arflow import CausalARFlow
+from strnn.models.causal_arflow import CausalARFlowTrainer
 
 BL_CONFIG_PATH = "./config/baseline.yaml"
 FM_CONFIG_PATH = "./config/masked.yaml"
@@ -38,7 +37,7 @@ print(args, flush=True)
 
 
 def get_model_config(args: argparse.Namespace, config: dict) -> dict:
-    """Updates model arch config with command line arguments.
+    """Update model arch config with command line arguments.
 
     Args:
         args: Command line arguments.
@@ -59,7 +58,6 @@ def get_model_config(args: argparse.Namespace, config: dict) -> dict:
 
 
 def main():
-
     np.random.seed(args.graph_seed)
     torch.manual_seed(2541)
 
@@ -109,8 +107,8 @@ def main():
         bl_config.arch_config[ADJ] = None
         fm_config.arch_config[ADJ] = bin_adj_mat
 
-        carefl = CausalARFlow(bl_config)
-        straf = CausalARFlow(fm_config)
+        carefl = CausalARFlowTrainer(bl_config)
+        straf = CausalARFlowTrainer(fm_config)
 
         # Train models
         carefl.fit_to_sem(dataset)
@@ -133,8 +131,8 @@ def main():
         overall_bl_error.append(bl_err)
         overall_fm_error.append(fm_err)
 
-    print(np.nanmean(overall_bl_error), np.nanstd(overall_bl_error), flush=True)
-    print(np.nanmean(overall_fm_error), np.nanstd(overall_fm_error), flush=True)
+    print(np.nanmean(overall_bl_error), np.nanstd(overall_bl_error))
+    print(np.nanmean(overall_fm_error), np.nanstd(overall_fm_error))
 
     exp_output = {
         "args": args,
@@ -146,8 +144,13 @@ def main():
     output_dir = "./output/"
     out_fn = "linadd{}_{}hid_{}obs_{}runs_{}"
 
-    out_fn = out_fn.format(args.n_graph_vars, args.hidden_width, args.data_samples,
-                        args.n_trials, args.eval)
+    out_fn = out_fn.format(
+        args.n_graph_vars,
+        args.hidden_width,
+        args.data_samples,
+        args.n_trials,
+        args.eval
+    )
 
     torch.save(exp_output, output_dir + out_fn + ".pt")
 

--- a/experiments/synthetic_causality/utils.py
+++ b/experiments/synthetic_causality/utils.py
@@ -1,6 +1,8 @@
 import argparse
 
+
 def dict2namespace(config):
+    """Convert dictionary to argparse namespace."""
     namespace = argparse.Namespace()
     for key, value in config.items():
         if isinstance(value, dict):

--- a/precommit.sh
+++ b/precommit.sh
@@ -2,4 +2,4 @@ python -m pytest
 mypy data --ignore-missing-imports
 mypy experiments --ignore-missing-imports
 mypy strnn --ignore-missing-imports
-flake8 . --ignore=F403,F405
+flake8 . --ignore=F403,F405,D100

--- a/precommit.sh
+++ b/precommit.sh
@@ -2,4 +2,4 @@ python -m pytest
 mypy data --ignore-missing-imports
 mypy experiments --ignore-missing-imports
 mypy strnn --ignore-missing-imports
-flake8 . --ignore=F403,F405,D100
+flake8 . --ignore=F403,F405,D100,D104

--- a/strnn/models/causal_arflow.py
+++ b/strnn/models/causal_arflow.py
@@ -185,8 +185,8 @@ class CausalAutoregressiveFlowWithPrior(nn.Module):
         if x_obs.shape[0] != 1:
             raise ValueError("Counterfactual only accepts single example.")
 
-        if type(x_obs) is np.ndarray:
-            x_obs = torch.Tensor(x_obs)
+        if isinstance(x_obs, np.ndarray):
+            x_obs = torch.from_numpy(x_obs)
 
         # abduction:
         z_obs = self.forward(x_obs)[0]
@@ -388,7 +388,7 @@ class CausalARFlowTrainer:
         val_losses = []
 
         best_val_loss = None
-        best_weights = None
+        best_weights = flow.state_dict()
         patience_counter = 0
 
         for e in range(self.epochs):

--- a/strnn/models/causal_arflow.py
+++ b/strnn/models/causal_arflow.py
@@ -1,293 +1,426 @@
 import numpy as np
+from sklearn.model_selection import train_test_split
+
 import torch
+import torch.nn as nn
 import torch.optim as optim
-from torch import nn
-from torch.distributions import Laplace, Uniform, TransformedDistribution, SigmoidTransform, Normal
-from torch.utils.data import DataLoader, Dataset
+
+from torch.distributions import Distribution, Laplace, Uniform, Normal
+from torch.distributions import TransformedDistribution, SigmoidTransform
+from torch.utils.data import DataLoader
 
 from data.causal_sem import CustomSyntheticDatasetDensity
-from strnn.models.discrete_flows import AutoregressiveFlow, AutoregressiveFlowFactory
+
+from strnn.models.discrete_flows import AutoregressiveFlow
+from strnn.models.discrete_flows import AutoregressiveFlowFactory
+
+from argparse import Namespace
 
 
-class CausalARFlow:
+class CausalAutoregressiveFlowWithPrior(nn.Module):
+    """Autoregressive flow generated from user specified prior distribution.
+
+    Can be used to define both the Causal StrAF and the baseline CAREFL model,
+    which is a Causal StrAF with a fully autoregressive adjacency matrix.
+
+    The CAREFL model developed in Causal Autoregressive Flows,
+    by Khemakhem et al. (2021) is available at:
+        https://arxiv.org/abs/2011.02268
+
+    The CAREFL and the Causal StrAF can be used to find causal direction
+    between pairs of (multivariate) random variables, or to perform
+    interventions and answer counterfactual queries.
+
+    Code to perform intervention and counterfactual queries have been adapted
+    from CAREFL, but several bugs have been fixed in our implementation. These
+    fixes have been noted in the correspond methods.
     """
-    The CAREFL model.
 
-    This class defines the CAREFL model developed in Causal Autoregressive Flows, by Khemakhem et al. (2021)
-    manuscript available at: https://arxiv.org/abs/2011.02268
+    def __init__(self, prior: Distribution, flow: AutoregressiveFlow):
+        """Initialize an autoregressive flow with a flexible prior.
 
-    CAREFL can be used to find causal direction between paris of (multivariate) random variables, or
-    to perform interventions and answer counterfactual queries.
-
-    Parameters:
-    ----------
-    config: dict
-        A configuration dict that defines all necessary parameters.
-        Refer to one of the provided config files for more info/
-
-    Methods:
-    ----------
-    fit_to_sem: fits an autoregressive flow model to an SEM.
-    predict_intervention: Perform an intervention on a given variable in a fitted DAG.
-    predict_counterfactual: Answer counterfactual queries on a fitted DAG.
-
-    """
-    def __init__(self, config):
-        self.config = config
-        self.arch_config = config.arch_config
-        self.n_layers = config.flow.nl
-        self.n_hidden = config.flow.nh
-        self.epochs = config.training.epochs
-        self.device = config.device
-        self.verbose = config.training.verbose
-
-        self.dim = None
-        self.direction = 'none'
-        self.flow = None
-
-
-    def fit_to_sem(self, data):
+        Args:
+            prior:
+                PyTorch distribution describing latent-space prior. Note that
+                the prior must match the dimensionality of the latent space,
+                as other methods use the prior to generate samples.
+            flow:
+                AR flow used to perform invertible transformations.
         """
-        Assuming data columns follow the causal ordering, we fit the associated SEM.
+        super().__init__()
+        self.prior = prior
+        self.flow = flow
 
-        Parameters:
-        ----------
-        data: numpy.ndarray
-            A dataset whose columns are ordered following the causal ordering \pi. The causal ordering
-            can be a result of causal discovery algorithm, or expert judgement.
+    def forward(
+        self,
+        x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Transform data-space samples to latent-space and get likelihood.
+
+        Args:
+            Data-space samples to normalize of shape (B x D)
+
+        Returns:
+            Normalized samples, log prior probability, and Jacobian determinant
         """
-        dset, test_dset, dim = self._get_datasets(data)
-        self.dim = dim
-        torch.manual_seed(self.config.training.seed)
-        flows, _ = self._train(dset)
+        zs, log_det = self.flow.forward(x)
+        prior_logprob = self.prior.log_prob(zs).view(x.size(0), -1).sum(1)
+        return zs, prior_logprob, log_det
 
-        # remove multiple flows training,
-        self.flow = flows[0]
-        # self.flow, score, self._nlxy, self._nhxy = self._evaluate(flows, test_dset)
-        # return score if return_scores else None
-    
+    def backward(self, z: torch.Tensor) -> torch.Tensor:
+        """Transform latent-space samples to data-space using flow.
 
-    def predict_intervention_modified(self, x0_val, n_samples=100, iidx=0):
+        Args:
+            z: Samples in latent-space of shape (B x D)
+
+        Returns:
+            Samples in data-space after flow transformation of shape (B x D)
         """
-        We predict the value of x given an intervention do(x_iidx = x0_val)
+        xs = self.flow.invert(z)
+        return xs
 
-        As explained in Appendix E.1, we do not need to invert the flow to perform interventions,
-        but doing so provides a simpler and more efficient algorithm. Thus, this implementation
-        will follow Algorithm 2 of Appendix E.1.
+    def sample(self, num_samples: int) -> torch.Tensor:
+        """Generate data-space samples using inverse flow transformation.
 
-        Warning: Algorithm 2 from the authors is wrong!!!!
+        Args:
+            num_samples: Number of samples to generate
 
-        This proceeds in 3 steps:
+        Returns:
+            Samples in data space generated from flow distribution
+        """
+        z = self.prior.sample(torch.Size((num_samples,)))
+        xs = self.flow.invert(z)
+        return xs
+
+    def log_likelihood(self, x: torch.Tensor) -> np.ndarray:
+        """Compute log likelihood of samples in data-space.
+
+        Args:
+            x: Data sample of shape (B x D)
+
+        Returns:
+            Log likelihood of data samples
+        """
+        _, prior_logprob, log_det = self.forward(x)
+        return (prior_logprob + log_det).detach().cpu().numpy()
+
+    def predict_intervention(
+        self,
+        x0_val: float,
+        n_samples: int = 100,
+        iidx: int = 0
+    ) -> np.ndarray:
+        """Predict the value of x given an intervention do(x_iidx = x0_val).
+
+        As explained in Appendix E.1 of the CAREFL paper, we do not need to
+        invert the flow to perform interventions, but doing so provides a
+        simpler and more efficient algorithm. Thus, this implementation will
+        follow Algorithm 2 of Appendix E.1.
+
+        However, the CAREFL implementation is actually incorrect, and has
+        been fixed here. The intervention proceeds as below:
+
         1) sample noises z from base distribution
         2) pass z through flow to get initial samples for x
         3) invert flow to find corresponding entry for z_iidx at x_iidx=x0_val
         4) pass z again through flow to get samples for x
+
+        Args:
+            x0_val: Interventional value
+            n_samples: Number of samples used to estimate interventional effect
+            iidx: Index of variable to intervene on
+
+        Return:
+            Estimate of interventional effect
         """
-        # sample from prior and ensure z_intervention_index = z_int
-        z = self.flow.prior.sample((n_samples,)).cpu().detach().numpy()
+        # Sample from prior and ensure z_intervention_index = z_int
+        z = self.prior.sample(torch.Size((n_samples,)))
 
-        # pass z through flow to get initial samples for x
-        x_init = self._backward_flow(z)
+        # Pass z through flow to get initial samples for x
+        x_init = self.backward(z)
 
-        # invert flow to infer value of latent corresponding to interventional variable
+        # Invert flow to infer value of latent corresponding to
+        # interventional variable
         x_init[:, iidx] = x0_val
-        z_int = self._forward_flow(x_init)[:, iidx]
+        z_int = self.forward(x_init)[0][:, iidx]
         z[:, iidx] = z_int
 
-        # propagate the latent sample through flow
-        x = self._backward_flow(z)
+        # Propagate the latent sample through flow
+        x = self.backward(z)
 
-        # sanity check: check x_intervention_index == x0_val
-        assert (np.abs(x[:, iidx] - x0_val) < 1e-3).all()
-        return x.mean(0).reshape((1, self.dim))
+        # Sanity check: check x_intervention_index == x0_val
+        assert (torch.abs(x[:, iidx] - x0_val) < 1e-3).all()
 
+        int_est = x.mean(0).reshape((1, z.shape[1]))
+        return int_est.detach().cpu().numpy()
 
-    def predict_counterfactual(self, x_obs, cf_val, iidx=0):
-        """
-        Given observation x_obs we estimate the counterfactual of setting x_obs[intervention_index] = cf_val
+    def predict_counterfactual(
+        self,
+        x_obs: torch.Tensor | np.ndarray,
+        cf_val: float,
+        iidx: int = 0
+    ) -> np.ndarray:
+        """Predict counterfactual of setting dimension iidx of x_obs to cf_val.
+
+        For clarity, we restrict counterfacutal queries to a single example.
+        However, this method can easily be extended to accept an array of
+        counterfactual values instead.
+
+        Given observation x_obs we estimate the counterfactual of setting
+        x_obs[intervention_index] = cf_val
 
         This proceeds in 3 steps:
          1) abduction - pass-forward through flow to infer latents for x_obs
          2) action - pass-forward again for latent associated with cf_val
          3) prediction - backward pass through the flow
+
+        Args:
+            x_obs: Observed data sample to perform counterfactual query.
+            cf_val: Counterfactual value.
+            iidx: Feature dimension of counterfactual value.
+
+        Returns:
+            Counterfactual of observed data sample
         """
+        if x_obs.shape[0] != 1:
+            raise ValueError("Counterfactual only accepts single example.")
+
+        if type(x_obs) is np.ndarray:
+            x_obs = torch.Tensor(x_obs)
+
         # abduction:
-        z_obs = self._forward_flow(x_obs)
+        z_obs = self.forward(x_obs)[0]
         # action (get latent variable value under counterfactual)
-        x_cf = np.copy(x_obs)
+        x_cf = torch.clone(x_obs)
         x_cf[0, iidx] = cf_val
-        z_cf_val = self._forward_flow(x_cf)[0, iidx]
+        z_cf_val = self.forward(x_cf)[0][0, iidx]
         z_obs[0, iidx] = z_cf_val
+
         # prediction (pass through the flow):
-        x_post_cf = self._backward_flow(z_obs)
-        return x_post_cf
-    
+        x_post_cf = self.backward(z_obs)
+        return x_post_cf.detach().cpu().numpy()
 
-    def _get_optimizer(self, parameters):
+
+class CausalARFlowTrainer:
+    """Wrapper around the Causal StrAF / CAREFL to allow easier training."""
+
+    def __init__(self, config: Namespace):
+        """Initialize a causal flow trainer.
+
+        Args:
+            config: Dictionary of model arguments. See below for parameters
+
+            config.arch_config: Config passed to AutoregressiveFlow init
+            config.device: CUDA device used for training
+            config.flow.prior_dist: Prior distribution used for likelihood
+            config.optim.adam_beta: Adam optimizer beta_1 coefficient
+            config.optim.amsgrad: Whether to use amsgrad in Adam optimizer
+            config.optim.lr: Optimization learning rate
+            config.optim.scheduler: Whether a learning rate scheduler is used
+            config.optim.weight_decay: Adam weight decay value
+            config.training.batch_size: Batch size used in training
+            config.training.epoch: Number of training epochs
+            config.training.seed: Random seed used for training
+            config.training.split: Training split ratio
+            config.training.verbose: Whether training logs are printed
         """
-        Returns an optimizer according to the config file
+        self.config: Namespace = config
+        self.arch_config: dict = config.arch_config
+        self.prior_dist: Distribution = config.flow.prior_dist
+
+        self.device: torch.device = config.device
+
+        self.adam_beta: float = config.optim.beta1
+        self.amsgrad: bool = config.optim.amsgrad
+        self.lr: float = config.optim.lr
+        self.scheduler: bool = config.optim.scheduler
+        self.weight_decay: float = config.optim.weight_decay
+
+        self.batch_size: int = config.training.batch_size
+        self.epochs: int = config.training.epochs
+        self.seed: int = config.training.seed
+        self.split_ratio: float = config.training.split
+        self.verbose: bool = config.training.verbose
+
+        self.dim: int | None = None
+        self.flow: CausalAutoregressiveFlowWithPrior | None = None
+
+    def fit_to_sem(self, data: np.ndarray) -> tuple[list[float], list[float]]:
+        """Fits SEM assuming data columns follow the causal ordering.
+
+        Args:
+            data:
+                A dataset whose columns are ordered following the causal
+                ordering $pi$. The causal ordering can be a result of causal
+                discovery algorithm, or expert judgement.
         """
-        optimizer = optim.Adam(parameters, lr=self.config.optim.lr, weight_decay=self.config.optim.weight_decay,
-                               betas=(self.config.optim.beta1, 0.999), amsgrad=self.config.optim.amsgrad)
-        if self.config.optim.scheduler:
-            scheduler = optim.lr_scheduler.ReduceLROnPlateau(optimizer, factor=0.1, patience=3, verbose=self.verbose)
+        train_dl, val_dl = self._get_datasets(data)
+
+        torch.manual_seed(self.seed)
+        self.flow = self._get_flow_arch()
+
+        train_losses, val_losses = self._train(self.flow, train_dl, val_dl)
+
+        return train_losses, val_losses
+
+    def _get_datasets(self, data: np.ndarray) -> tuple[DataLoader, DataLoader]:
+        """Get train/val dataset splits from overall design matrix.
+
+        Args:
+            dataset: Observed samples
+
+        Returns:
+            Training and validation dataloaders
+        """
+        assert isinstance(data, np.ndarray)
+
+        self.dim = data.shape[-1]
+
+        train_np, val_np = train_test_split(data, train_size=self.split_ratio)
+
+        train = CustomSyntheticDatasetDensity(train_np)
+        val = CustomSyntheticDatasetDensity(val_np)
+
+        train_dl = DataLoader(train, shuffle=True, batch_size=self.batch_size)
+        val_dl = DataLoader(val, shuffle=False, batch_size=self.batch_size)
+
+        return train_dl, val_dl
+
+    def _get_flow_arch(self) -> CausalAutoregressiveFlowWithPrior:
+        """Return a normalizing flow according to the config file.
+
+        Returns:
+            Initialized Causal Autoregressive Flow (Causal StrAF or CAREFL).
+        """
+        if self.dim is None:
+            raise RuntimeError("self._get_datasets must be called first.")
+
+        prior: Distribution | None = None
+
+        # Setup priors
+        if self.prior_dist == 'laplace':
+            prior = Laplace(
+                torch.zeros(self.dim).to(self.device),
+                torch.ones(self.dim).to(self.device)
+            )
+        elif self.prior_dist == 'normal':
+            prior = Normal(
+                torch.zeros(self.dim).to(self.device),
+                torch.ones(self.dim).to(self.device)
+            )
         else:
-            scheduler = None
-        return optimizer, scheduler
-    
+            prior = TransformedDistribution(
+                Uniform(
+                    torch.zeros(self.dim).to(self.device),
+                    torch.ones(self.dim).to(self.device)
+                ),
+                SigmoidTransform().inv
+            )
 
-    def _get_flow_arch(self):
-        """
-        Returns a normalizing flow according to the config file.
-
-        Parameters:
-        """
-        # this method only gets called by _train, which in turn is only called after self.dim has been initialized
-        dim = self.dim
-        # prior
-        if self.config.flow.prior_dist == 'laplace':
-            prior = Laplace(torch.zeros(dim).to(self.device), torch.ones(dim).to(self.device))
-        elif self.config.flow.prior_dist == 'normal':
-            prior = Normal(torch.zeros(dim).to(self.device), torch.ones(dim).to(self.device))
-        else:
-            prior = TransformedDistribution(Uniform(torch.zeros(dim).to(self.device), torch.ones(dim).to(self.device)),
-                                            SigmoidTransform().inv)
-        # autoregressive flow
+        # Build flow model
         model_factory = AutoregressiveFlowFactory(self.arch_config)
         flow = model_factory.build_flow()
 
-        normalizing_flows = []
-        normalizing_flows.append(AutoregressiveFlowModel(prior, flow).to(self.device))
-        return normalizing_flows
-    
+        assert isinstance(flow, AutoregressiveFlow)
 
-    def _train(self, dset):
+        return CausalAutoregressiveFlowWithPrior(prior, flow).to(self.device)
+
+    def _get_optimizer(
+        self,
+        model: CausalAutoregressiveFlowWithPrior,
+    ) -> tuple[optim.Optimizer, optim.lr_scheduler.ReduceLROnPlateau | None]:
+        """Return an optimizer according to the config file.
+
+        Args:
+            model: Model to optimize
+
+        Returns:
+            Initialized Adam optimizer, and optionally a LR scheduler
         """
-        Train one or multiple flors for a single direction, specified by `parity`.
+        optimizer = optim.Adam(
+            model.parameters(),
+            lr=self.lr,
+            weight_decay=self.weight_decay,
+            betas=(self.adam_beta, 0.999),
+            amsgrad=self.amsgrad
+        )
+
+        if self.scheduler:
+            scheduler = optim.lr_scheduler.ReduceLROnPlateau(
+                optimizer,
+                factor=0.1,
+                patience=3,
+                verbose=self.verbose
+            )
+        else:
+            scheduler = None
+
+        return optimizer, scheduler
+
+    def _train(
+        self,
+        flow: CausalAutoregressiveFlowWithPrior,
+        train_dl: DataLoader,
+        val_dl: DataLoader
+    ) -> tuple[list, list]:
+        """Train causal autoregressive flow.
+
+        Args:
+            flow: Causal autoregressive flow to train
+            train_dl: Train dataloader
+            val_dl: Validation dataloader
+
+        Returns:
+            Train and validation losses throughout training.
         """
-        train_loader = DataLoader(dset, shuffle=True, batch_size=self.config.training.batch_size)
-        flows = self._get_flow_arch()
-        all_loss_vals = []
-        for flow in flows:
-            optimizer, scheduler = self._get_optimizer(flow.parameters())
-            flow.train()
-            loss_vals = []
-            for e in range(self.epochs):
-                loss_val = 0
-                for _, x in enumerate(train_loader):
-                    x = x.to(self.device)
+        optimizer, scheduler = self._get_optimizer(flow)
+
+        flow.train()
+
+        train_losses = []
+        val_losses = []
+
+        for e in range(self.epochs):
+            epoch_t_loss = []
+            epoch_v_loss = []
+
+            for train_batch in train_dl:
+                optimizer.zero_grad()
+                train_batch = train_batch.to(self.device)
+
+                # compute loss
+                _, prior_logprob, log_det = flow(train_batch)
+                train_loss = -torch.sum(prior_logprob + log_det)
+                epoch_t_loss.append(train_loss.item())
+
+                # optimize
+                train_loss.backward()
+                optimizer.step()
+
+            with torch.no_grad():
+                flow.eval()
+
+                for val_batch in val_dl:
+                    val_batch = val_batch.to(self.device)
+
                     # compute loss
-                    _, prior_logprob, log_det = flow(x)
-                    loss = - torch.sum(prior_logprob + log_det)
-                    loss_val += loss.item()
-                    # optimize
-                    optimizer.zero_grad()
-                    loss.backward()
-                    optimizer.step()
-                if self.config.optim.scheduler:
-                    scheduler.step(loss_val / len(train_loader))
-                if self.verbose:
-                    print('epoch {}/{} \tloss: {}'.format(e, self.epochs, loss_val))
-                loss_vals.append(loss_val)
-            all_loss_vals.append(loss_vals)
-        return flows, all_loss_vals
+                    _, prior_logprob, log_det = flow(val_batch)
+                    val_loss = -torch.sum(prior_logprob + log_det)
+                    epoch_v_loss.append(val_loss.item())
 
+                flow.train()
 
-    def _get_params_from_idx(self, idx):
-        return self.n_layers[idx // len(self.n_hidden)], self.n_hidden[idx % len(self.n_hidden)]
+            epoch_t_mean = np.mean(epoch_t_loss)
+            epoch_v_mean = np.mean(epoch_v_loss)
 
+            if self.scheduler and scheduler is not None:
+                scheduler.step(epoch_t_mean)
 
-    def _evaluate(self, flows, test_dset, parity=False):
-        """
-        Evaluate a set of flows on test dataset, and return the one with best test likelihood.
-        """
-        loader = DataLoader(test_dset, batch_size=128)
-        scores = []
-        for idx, flow in enumerate(flows):
-            if parity and self.config.flow.architecture == 'spline':
-                # spline flows don't have parity option and should only be used with 2D numpy data:
-                score = np.nanmean(np.concatenate([flow.log_likelihood(x.to(self.device)[:, [1, 0]]) for x in loader]))
-            else:
-                score = np.nanmean(np.concatenate([flow.log_likelihood(x.to(self.device)) for x in loader]))
-            scores.append(score)
-        try:
-            # in case all scores are nan, this will raise a ValueError
-            idx = np.nanargmax(scores)
-        except ValueError:
-            # arbitrarily pick flows[0], this doesn't matter since best_score = nan, which will
-            idx = 0
-        # unlike nanargmax, nanmax only raises a RuntimeWarning when all scores are nan, and will return nan
-        best_score = np.nanmax(scores)
-        best_flow = flows[idx]
-        nl, nh = self._get_params_from_idx(idx)  # for debug
-        return best_flow, best_score, nl, nh
+            if self.verbose:
+                msg = "Epoch {}/{} \tTrain loss: {}\t Val loss: {}"
+                print(msg.format(e, self.epochs, epoch_t_mean, epoch_v_mean))
 
+            train_losses.append(epoch_t_mean)
+            val_losses.append(epoch_v_mean)
 
-    def _get_datasets(self, input):
-        """
-        Check data type, which can be:
-            - an np.ndarray, in which case split it and wrap it into a train Dataset and and a test Dataset
-            - a Dataset, in which case duplicate it (test dataset is the same as train dataset)
-            - a tuple of Datasets, in which case just return.
-        return a train Dataset, and a test Dataset
-        """
-        assert isinstance(input, (np.ndarray, Dataset, tuple, list))
-        if isinstance(input, np.ndarray):
-            dim = input.shape[-1]
-            if self.config.training.split == 1.:
-                data_test = np.copy(input)
-            else:
-                data_test = np.copy(input[int(self.config.training.split * input.shape[0]):])
-                input = input[:int(self.config.training.split * input.shape[0])]
-            dset = CustomSyntheticDatasetDensity(input.astype(np.float32))
-            test_dset = CustomSyntheticDatasetDensity(data_test.astype(np.float32))
-            return dset, test_dset, dim
-        if isinstance(input, Dataset):
-            dim = input[0].shape[-1]
-            return input, input, dim
-        if isinstance(input, (tuple, list)):
-            dim = input[0][0].shape[-1]
-            return input[0], input[1], dim
-
-    def _update_dir(self, p):
-        self.flow = self.flow_xy if p >= 0 else self.flow_yx
-        self.direction = 'x->y' if p >= 0 else 'y->x'
-
-    def _forward_flow(self, data):
-        if self.flow is None:
-            raise ValueError('Model needs to be fitted first')
-        return self.flow.forward(torch.tensor(data.astype(np.float32)).to(self.device))[0].detach().cpu().numpy()
-
-    def _backward_flow(self, latent):
-        if self.flow is None:
-            raise ValueError('Model needs to be fitted first')
-        return self.flow.backward(torch.tensor(latent.astype(np.float32)).to(self.device)).detach().cpu().numpy()
-    
-
-class AutoregressiveFlowModel(nn.Module):
-    """ A Normalizing Flow Model is a (prior, flow) pair """
-
-    def __init__(self, prior, flow: AutoregressiveFlow):
-        super().__init__()
-        self.prior = prior
-        self.flow = flow
-
-    def forward(self, x):
-        zs, log_det = self.flow.forward(x)
-        prior_logprob = self.prior.log_prob(zs).view(x.size(0), -1).sum(1)
-        return zs, prior_logprob, log_det
-
-    def backward(self, z):
-        xs = self.flow.invert(z)
-        return xs
-
-    def sample(self, num_samples):
-        z = self.prior.sample((num_samples,))
-        xs = self.flow.invert(z)
-        return xs
-
-    def log_likelihood(self, x):
-        if type(x) is np.ndarray:
-            x = torch.tensor(x.astype(np.float32))
-        _, prior_logprob, log_det = self.forward(x)
-        return (prior_logprob + log_det).cpu().detach().numpy()
+        return train_losses, val_losses

--- a/test/models/test_causal_arflow.py
+++ b/test/models/test_causal_arflow.py
@@ -1,0 +1,111 @@
+import pytest
+from unittest.mock import Mock
+
+import numpy as np
+
+import torch
+import torch.distributions as dist
+
+from strnn.models.causal_arflow import CausalAutoregressiveFlowWithPrior
+from strnn.models.discrete_flows import AutoregressiveFlow
+
+
+@pytest.fixture
+def mock_flow():
+    """Mock autoregressive flow which has identity forward and backwards."""
+    def identity_forward(in_val):
+        return in_val, in_val
+
+    def identity_back(in_val):
+        return in_val
+
+    mock_flow = Mock(spec=AutoregressiveFlow)
+
+    mock_flow.forward = Mock(side_effect=identity_forward)
+    mock_flow.invert = Mock(side_effect=identity_back)
+
+    return mock_flow
+
+
+def test_forward(mock_flow):
+    """Test that the CausalAF simply passthroughs the AF forward."""
+    test_in = torch.randn(8, 16)
+
+    prior_dist = dist.Normal(0, 1)
+    model = CausalAutoregressiveFlowWithPrior(prior_dist, mock_flow)
+
+    z, prior_prob, _ = model.forward(test_in)
+
+    assert torch.all(z == test_in)
+    assert torch.all(prior_prob == prior_dist.log_prob(test_in).sum(1))
+
+
+def test_backward(mock_flow):
+    """Test that the CausalAF simply passthroughs the AF backward."""
+    test_in = torch.randn(8, 16)
+
+    prior = dist.Normal(0, 1)
+    model = CausalAutoregressiveFlowWithPrior(prior, mock_flow)
+
+    x = model.backward(test_in)
+
+    assert torch.all(x == test_in)
+
+
+def test_sample(mock_flow):
+    """Test Casual AF sampling."""
+    prior = dist.Normal(torch.zeros(3), torch.ones(3))
+    model = CausalAutoregressiveFlowWithPrior(prior, mock_flow)
+
+    samples = model.sample(100)
+
+    assert samples.shape == (100, 3)
+
+
+def test_interventional(mock_flow):
+    """Test interventional estimation.
+
+    TODO: This could likely be made a more robust test by creating a mock
+    flow which actually depends on the value of the intervention, but alas...
+    """
+    n_samp = 10
+    n_dim = 3
+
+    # Mock a fixed prior distribution sample
+    mock_prior = Mock(spec=dist.Normal)
+    mock_prior.sample.return_value = torch.ones(n_samp, n_dim)
+
+    model = CausalAutoregressiveFlowWithPrior(mock_prior, mock_flow)
+
+    int_est = model.predict_intervention(2, n_samp, 1)
+
+    assert int_est.shape == (1, n_dim)
+    assert np.all(int_est == np.array([[1, 2, 1]]))
+
+
+def test_counterfactual_multi_errors(mock_flow):
+    """Test that feeding multiple samples into counterfactual raises error."""
+    with pytest.raises(ValueError):
+        test_in = torch.randn(10, 3)
+
+        prior = dist.Normal(0, 1)
+        model = CausalAutoregressiveFlowWithPrior(prior, mock_flow)
+
+        model.predict_counterfactual(test_in, 3, 1)
+
+
+def test_counterfactual(mock_flow):
+    """Test that counterfactual inference works.
+
+    TODO: This could likely be made a more robust test by creating a mock
+    flow which actually returns a conditional output based on correct
+    substitution of counterfactual.
+    """
+    prior = dist.Normal(0, 1)
+    model = CausalAutoregressiveFlowWithPrior(prior, mock_flow)
+
+    test_in = torch.ones(1, 3)
+    ctf_est = model.predict_counterfactual(test_in, 3, 1)
+
+    assert ctf_est.shape == (1, 3)
+    assert np.all(ctf_est == np.array([[1, 3, 1]]))


### PR DESCRIPTION
Cleaned up code associated with Causal StrAF. Changes include:

- Split CausalARFlow into two classes. First contains just the model architecture, and the second contains training code.
- CausalARFlowTrainer now implements an early stopping procedure based on validation loss.
- Added unit testing and docstrings for most functions in causality section.